### PR TITLE
Task/日本語

### DIFF
--- a/.github/workflows/日本語テスト.yml
+++ b/.github/workflows/日本語テスト.yml
@@ -1,0 +1,11 @@
+name: 日本語テスト.
+on:
+  push:
+    branches-ignore:
+      - master
+jobs:
+  日本語ジョブ名:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Event name is ${{ github.event_name }}."
+      - run: echo "Brnach name is ${{ github.ref }}."

--- a/.github/workflows/日本語テスト.yml
+++ b/.github/workflows/日本語テスト.yml
@@ -4,7 +4,9 @@ on:
     branches-ignore:
       - master
 jobs:
-  日本語ジョブ名:
+  #The workflow is not valid. .github/workflows/日本語テスト.yml (Line: 7, Col: 3): The identifier '日本語ジョブ名' is invalid. IDs may only contain alphanumeric characters, '_', and '-'. IDs must start with a letter or '_' and and must be less than 100 characters.
+  job_id:
+    name: 日本語ジョブ
     runs-on: ubuntu-latest
     steps:
       - run: echo "Event name is ${{ github.event_name }}."


### PR DESCRIPTION
**対応内容**
日本語文字をどこまで使えるか確認。
以下のエラーメッセージが出てジョブIDには日本語を使えないことが分かった。
```
The workflow is not valid. .github/workflows/日本語テスト.yml (Line: 7, Col: 3): The identifier '日本語ジョブ名' is invalid. IDs may only contain alphanumeric characters, '_', and '-'. IDs must start with a letter or '_' and and must be less than 100 characters.
```
ジョブ名には日本語を使える。
[こちら](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobs)
