### PR TITLE
ジョブ名をジョブIDを参照して設定

### DIFF
--- a/.github/workflows/github-context.yml
+++ b/.github/workflows/github-context.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   FIRST-JOB:
-    name: $${{ github.job }}
+    name: ${{ github.job }}
     runs-on: ubuntu-latest
     steps:
       - run: echo "Event name is ${{ github.event_name }}."

--- a/.github/workflows/github-context.yml
+++ b/.github/workflows/github-context.yml
@@ -1,0 +1,13 @@
+name: Github-Actions. github contexts.
+on:
+  push:
+    branches:
+      - task/github-action-context/github
+
+jobs:
+  FIRST-JOB:
+    name: $${{ github.job }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Event name is ${{ github.event_name }}."
+      - run: echo "Brnach name is ${{ github.ref }}."


### PR DESCRIPTION
**やったこと**
ジョブ名として、ジョブIDを参照して設定を行う。

**参考**
ジョブ名がjob_idを参照していることがわかる。
![image](https://user-images.githubusercontent.com/4788466/137590192-07e6e316-b97f-44e2-8c9e-b232f5f255b8.png)
**失敗**
$二回重ねたためエスケープされ式として認識されなかった場合は以下となる。
![image](https://user-images.githubusercontent.com/4788466/137590284-c01a0dc6-466f-4c21-858f-775dc4c6e81e.png)

ジョブ名に日本語を設定した場合
![image](https://user-images.githubusercontent.com/4788466/137590347-d77ba3e1-a021-47d4-a5b2-d61db89c52be.png)

デフォルトはジョブIDになるため実際はジョブIDを指定する必要はない。
![image](https://user-images.githubusercontent.com/4788466/137590415-59d0f17e-c755-49e5-baa8-f8062d237da9.png)
